### PR TITLE
fix: add Terraform state permissions to GitHub Actions IAM role

### DIFF
--- a/infrastructure/terraform/modules/iam/github_oidc.tf
+++ b/infrastructure/terraform/modules/iam/github_oidc.tf
@@ -145,6 +145,30 @@ resource "aws_iam_role_policy" "github_actions" {
           "arn:aws:rds:${var.aws_region}:${data.aws_caller_identity.current.account_id}:db:${var.project_name}-*",
           "arn:aws:rds:${var.aws_region}:${data.aws_caller_identity.current.account_id}:snapshot:${var.project_name}-*"
         ]
+      },
+      {
+        Sid    = "TerraformState"
+        Effect = "Allow"
+        Action = [
+          "s3:ListBucket",
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject"
+        ]
+        Resource = [
+          "arn:aws:s3:::${var.project_name}-terraform-state-${data.aws_caller_identity.current.account_id}",
+          "arn:aws:s3:::${var.project_name}-terraform-state-${data.aws_caller_identity.current.account_id}/*"
+        ]
+      },
+      {
+        Sid    = "TerraformLock"
+        Effect = "Allow"
+        Action = [
+          "dynamodb:GetItem",
+          "dynamodb:PutItem",
+          "dynamodb:DeleteItem"
+        ]
+        Resource = "arn:aws:dynamodb:${var.aws_region}:${data.aws_caller_identity.current.account_id}:table/${var.project_name}-terraform-locks"
       }
     ]
   })


### PR DESCRIPTION
Add S3 and DynamoDB permissions to enable GitHub Actions to manage Terraform state during CI/CD Infrastructure workflows.

- S3: ListBucket, GetObject, PutObject, DeleteObject for state storage
- DynamoDB: GetItem, PutItem, DeleteItem for state locking

🤖 Generated with [Claude Code](https://claude.com/claude-code)